### PR TITLE
Expose sections

### DIFF
--- a/op_msg.go
+++ b/op_msg.go
@@ -92,6 +92,22 @@ func (msg *OpMsg) RawSection0() wirebson.RawDocument {
 	return nil
 }
 
+// RawSections1 returns the value of all sections with kind 1.
+func (msg *OpMsg) RawSections1() []wirebson.RawDocument {
+	var seq []wirebson.RawDocument
+
+	for _, s := range msg.Sections() {
+		switch s.kind {
+		case 1:
+			for _, d := range s.documents {
+				seq = append(seq, d)
+			}
+		}
+	}
+
+	return seq
+}
+
 // RawSections returns the value of section with kind 0 and the value of all sections with kind 1.
 func (msg *OpMsg) RawSections() (wirebson.RawDocument, []byte) {
 	var spec wirebson.RawDocument

--- a/op_msg.go
+++ b/op_msg.go
@@ -94,18 +94,18 @@ func (msg *OpMsg) RawSection0() wirebson.RawDocument {
 
 // RawSections1 returns the value of all sections with kind 1.
 func (msg *OpMsg) RawSections1() []wirebson.RawDocument {
-	var seq []wirebson.RawDocument
+	var docs []wirebson.RawDocument
 
 	for _, s := range msg.Sections() {
 		switch s.kind {
 		case 1:
 			for _, d := range s.documents {
-				seq = append(seq, d)
+				docs = append(docs, d)
 			}
 		}
 	}
 
-	return seq
+	return docs
 }
 
 // RawSections returns the value of section with kind 0 and the value of all sections with kind 1.

--- a/op_msg.go
+++ b/op_msg.go
@@ -92,22 +92,6 @@ func (msg *OpMsg) RawSection0() wirebson.RawDocument {
 	return nil
 }
 
-// RawSections1 returns the value of all sections with Kind 1.
-func (msg *OpMsg) RawSections1() []wirebson.RawDocument {
-	var docs []wirebson.RawDocument
-
-	for _, s := range msg.Sections() {
-		switch s.Kind {
-		case 1:
-			for _, d := range s.Documents {
-				docs = append(docs, d)
-			}
-		}
-	}
-
-	return docs
-}
-
 // RawSections returns the value of section with Kind 0 and the value of all sections with Kind 1.
 func (msg *OpMsg) RawSections() (wirebson.RawDocument, []byte) {
 	var spec wirebson.RawDocument

--- a/op_msg.go
+++ b/op_msg.go
@@ -81,7 +81,7 @@ func (msg *OpMsg) SetSections(sections ...OpMsgSection) error {
 	return nil
 }
 
-// RawSection0 returns the value of first section with Kind 0.
+// RawSection0 returns the value of first section with kind 0.
 func (msg *OpMsg) RawSection0() wirebson.RawDocument {
 	for _, s := range msg.Sections() {
 		if s.Kind == 0 {
@@ -92,7 +92,7 @@ func (msg *OpMsg) RawSection0() wirebson.RawDocument {
 	return nil
 }
 
-// RawSections returns the value of section with Kind 0 and the value of all sections with Kind 1.
+// RawSections returns the value of section with kind 0 and the value of all sections with kind 1.
 func (msg *OpMsg) RawSections() (wirebson.RawDocument, []byte) {
 	var spec wirebson.RawDocument
 	var seq []byte

--- a/op_msg.go
+++ b/op_msg.go
@@ -28,7 +28,7 @@ type OpMsg struct {
 	// The order of fields is weird to make the struct smaller due to alignment.
 	// The wire order is: flags, sections, optional checksum.
 
-	sections []opMsgSection
+	sections []OpMsgSection
 	Flags    OpMsgFlags
 	checksum uint32
 }
@@ -41,7 +41,7 @@ func NewOpMsg(doc wirebson.AnyDocument) (*OpMsg, error) {
 	}
 
 	var msg OpMsg
-	if err = msg.SetSections(opMsgSection{documents: []wirebson.RawDocument{raw}}); err != nil {
+	if err = msg.SetSections(OpMsgSection{Documents: []wirebson.RawDocument{raw}}); err != nil {
 		return nil, lazyerrors.Error(err)
 	}
 
@@ -60,12 +60,12 @@ func MustOpMsg(pairs ...any) *OpMsg {
 }
 
 // Sections returns the sections of the OpMsg.
-func (msg *OpMsg) Sections() []opMsgSection {
+func (msg *OpMsg) Sections() []OpMsgSection {
 	return msg.sections
 }
 
 // SetSections sets sections of the OpMsg.
-func (msg *OpMsg) SetSections(sections ...opMsgSection) error {
+func (msg *OpMsg) SetSections(sections ...OpMsgSection) error {
 	if err := checkSections(sections); err != nil {
 		return lazyerrors.Error(err)
 	}
@@ -81,25 +81,25 @@ func (msg *OpMsg) SetSections(sections ...opMsgSection) error {
 	return nil
 }
 
-// RawSection0 returns the value of first section with kind 0.
+// RawSection0 returns the value of first section with Kind 0.
 func (msg *OpMsg) RawSection0() wirebson.RawDocument {
 	for _, s := range msg.Sections() {
-		if s.kind == 0 {
-			return s.documents[0]
+		if s.Kind == 0 {
+			return s.Documents[0]
 		}
 	}
 
 	return nil
 }
 
-// RawSections1 returns the value of all sections with kind 1.
+// RawSections1 returns the value of all sections with Kind 1.
 func (msg *OpMsg) RawSections1() []wirebson.RawDocument {
 	var docs []wirebson.RawDocument
 
 	for _, s := range msg.Sections() {
-		switch s.kind {
+		switch s.Kind {
 		case 1:
-			for _, d := range s.documents {
+			for _, d := range s.Documents {
 				docs = append(docs, d)
 			}
 		}
@@ -108,18 +108,18 @@ func (msg *OpMsg) RawSections1() []wirebson.RawDocument {
 	return docs
 }
 
-// RawSections returns the value of section with kind 0 and the value of all sections with kind 1.
+// RawSections returns the value of section with Kind 0 and the value of all sections with Kind 1.
 func (msg *OpMsg) RawSections() (wirebson.RawDocument, []byte) {
 	var spec wirebson.RawDocument
 	var seq []byte
 
 	for _, s := range msg.Sections() {
-		switch s.kind {
+		switch s.Kind {
 		case 0:
-			spec = s.documents[0]
+			spec = s.Documents[0]
 
 		case 1:
-			for _, d := range s.documents {
+			for _, d := range s.Documents {
 				seq = append(seq, d...)
 			}
 		}
@@ -138,11 +138,11 @@ func (msg *OpMsg) RawDocument() (wirebson.RawDocument, error) {
 	}
 
 	s := msg.sections[0]
-	if s.kind != 0 || s.identifier != "" {
-		return nil, lazyerrors.Errorf(`expected section 0/"", got %d/%q`, s.kind, s.identifier)
+	if s.Kind != 0 || s.Identifier != "" {
+		return nil, lazyerrors.Errorf(`expected section 0/"", got %d/%q`, s.Kind, s.Identifier)
 	}
 
-	return s.documents[0], nil
+	return s.Documents[0], nil
 }
 
 func (msg *OpMsg) msgbody() {}
@@ -150,7 +150,7 @@ func (msg *OpMsg) msgbody() {}
 // check implements [MsgBody].
 func (msg *OpMsg) check() error {
 	for _, s := range msg.sections {
-		for _, d := range s.documents {
+		for _, d := range s.Documents {
 			if _, err := d.DecodeDeep(); err != nil {
 				return lazyerrors.Error(err)
 			}
@@ -171,18 +171,18 @@ func (msg *OpMsg) UnmarshalBinaryNocopy(b []byte) error {
 	offset := 4
 
 	for {
-		var section opMsgSection
-		section.kind = b[offset]
+		var section OpMsgSection
+		section.Kind = b[offset]
 		offset++
 
-		switch section.kind {
+		switch section.Kind {
 		case 0:
 			l, err := wirebson.FindRaw(b[offset:])
 			if err != nil {
 				return lazyerrors.Error(err)
 			}
 
-			section.documents = []wirebson.RawDocument{b[offset : offset+l]}
+			section.Documents = []wirebson.RawDocument{b[offset : offset+l]}
 			offset += l
 
 		case 1:
@@ -203,13 +203,13 @@ func (msg *OpMsg) UnmarshalBinaryNocopy(b []byte) error {
 				return lazyerrors.Errorf("len(b) = %d, offset = %d", len(b), offset)
 			}
 
-			section.identifier, err = wirebson.DecodeCString(b[offset:])
+			section.Identifier, err = wirebson.DecodeCString(b[offset:])
 			if err != nil {
 				return lazyerrors.Error(err)
 			}
 
-			offset += wirebson.SizeCString(section.identifier)
-			secSize -= wirebson.SizeCString(section.identifier)
+			offset += wirebson.SizeCString(section.Identifier)
+			secSize -= wirebson.SizeCString(section.Identifier)
 
 			for secSize != 0 {
 				if secSize < 0 {
@@ -225,13 +225,13 @@ func (msg *OpMsg) UnmarshalBinaryNocopy(b []byte) error {
 					return lazyerrors.Error(err)
 				}
 
-				section.documents = append(section.documents, b[offset:offset+l])
+				section.Documents = append(section.Documents, b[offset:offset+l])
 				offset += l
 				secSize -= l
 			}
 
 		default:
-			return lazyerrors.Errorf("kind is %d", section.kind)
+			return lazyerrors.Errorf("kind is %d", section.Kind)
 		}
 
 		msg.sections = append(msg.sections, section)
@@ -283,17 +283,17 @@ func (msg *OpMsg) MarshalBinary() ([]byte, error) {
 	binary.LittleEndian.PutUint32(b, uint32(msg.Flags))
 
 	for _, section := range msg.sections {
-		b = append(b, section.kind)
+		b = append(b, section.Kind)
 
-		switch section.kind {
+		switch section.Kind {
 		case 0:
-			b = append(b, section.documents[0]...)
+			b = append(b, section.Documents[0]...)
 
 		case 1:
-			sec := make([]byte, wirebson.SizeCString(section.identifier))
-			wirebson.EncodeCString(sec, section.identifier)
+			sec := make([]byte, wirebson.SizeCString(section.Identifier))
+			wirebson.EncodeCString(sec, section.Identifier)
 
-			for _, doc := range section.documents {
+			for _, doc := range section.Documents {
 				sec = append(sec, doc...)
 			}
 
@@ -303,7 +303,7 @@ func (msg *OpMsg) MarshalBinary() ([]byte, error) {
 			b = append(b, sec...)
 
 		default:
-			return nil, lazyerrors.Errorf("kind is %d", section.kind)
+			return nil, lazyerrors.Errorf("kind is %d", section.Kind)
 		}
 	}
 
@@ -332,12 +332,12 @@ func (msg *OpMsg) logMessage(logFunc func(v any) string) string {
 	sections := wirebson.MakeArray(len(msg.sections))
 	for _, section := range msg.sections {
 		s := wirebson.MustDocument(
-			"Kind", int32(section.kind),
+			"Kind", int32(section.Kind),
 		)
 
-		switch section.kind {
+		switch section.Kind {
 		case 0:
-			doc, err := section.documents[0].DecodeDeep()
+			doc, err := section.Documents[0].DecodeDeep()
 			if err == nil {
 				must.NoError(s.Add("Document", doc))
 			} else {
@@ -345,10 +345,10 @@ func (msg *OpMsg) logMessage(logFunc func(v any) string) string {
 			}
 
 		case 1:
-			must.NoError(s.Add("Identifier", section.identifier))
-			docs := wirebson.MakeArray(len(section.documents))
+			must.NoError(s.Add("Identifier", section.Identifier))
+			docs := wirebson.MakeArray(len(section.Documents))
 
-			for _, d := range section.documents {
+			for _, d := range section.Documents {
 				doc, err := d.DecodeDeep()
 				if err == nil {
 					must.NoError(docs.Add(doc))
@@ -360,7 +360,7 @@ func (msg *OpMsg) logMessage(logFunc func(v any) string) string {
 			must.NoError(s.Add("Documents", docs))
 
 		default:
-			panic(fmt.Sprintf("unknown kind %d", section.kind))
+			panic(fmt.Sprintf("unknown kind %d", section.Kind))
 		}
 
 		must.NoError(sections.Add(s))

--- a/op_msg_section.go
+++ b/op_msg_section.go
@@ -65,8 +65,3 @@ func checkSections(sections []OpMsgSection) error {
 
 	return nil
 }
-
-// Section returns an identifier and documents of the section.
-func (s *OpMsgSection) Section() (string, []wirebson.RawDocument) {
-	return s.Identifier, s.Documents
-}

--- a/op_msg_section.go
+++ b/op_msg_section.go
@@ -65,3 +65,8 @@ func checkSections(sections []opMsgSection) error {
 
 	return nil
 }
+
+// Section returns an identifier and documents of the section.
+func (s *opMsgSection) Section() (string, []wirebson.RawDocument) {
+	return s.identifier, s.documents
+}

--- a/op_msg_section.go
+++ b/op_msg_section.go
@@ -19,18 +19,18 @@ import (
 	"github.com/FerretDB/wire/wirebson"
 )
 
-// opMsgSection is one or more sections contained in an OpMsg.
-type opMsgSection struct {
+// OpMsgSection is one or more sections contained in an OpMsg.
+type OpMsgSection struct {
 	// The order of fields is weird to make the struct smaller due to alignment.
-	// The wire order is: kind, identifier, documents.
+	// The wire order is: Kind, Identifier, Documents.
 
-	identifier string
-	documents  []wirebson.RawDocument
-	kind       byte
+	Identifier string
+	Documents  []wirebson.RawDocument
+	Kind       byte
 }
 
 // checkSections checks given sections.
-func checkSections(sections []opMsgSection) error {
+func checkSections(sections []OpMsgSection) error {
 	if len(sections) == 0 {
 		return lazyerrors.New("no sections")
 	}
@@ -38,28 +38,28 @@ func checkSections(sections []opMsgSection) error {
 	var kind0Found bool
 
 	for _, s := range sections {
-		switch s.kind {
+		switch s.Kind {
 		case 0:
 			if kind0Found {
 				return lazyerrors.New("multiple kind 0 sections")
 			}
 			kind0Found = true
 
-			if s.identifier != "" {
+			if s.Identifier != "" {
 				return lazyerrors.New("kind 0 section has identifier")
 			}
 
-			if len(s.documents) != 1 {
-				return lazyerrors.Errorf("kind 0 section has %d documents", len(s.documents))
+			if len(s.Documents) != 1 {
+				return lazyerrors.Errorf("kind 0 section has %d documents", len(s.Documents))
 			}
 
 		case 1:
-			if s.identifier == "" {
+			if s.Identifier == "" {
 				return lazyerrors.New("kind 1 section has no identifier")
 			}
 
 		default:
-			return lazyerrors.Errorf("unknown kind %d", s.kind)
+			return lazyerrors.Errorf("unknown kind %d", s.Kind)
 		}
 	}
 
@@ -67,6 +67,6 @@ func checkSections(sections []opMsgSection) error {
 }
 
 // Section returns an identifier and documents of the section.
-func (s *opMsgSection) Section() (string, []wirebson.RawDocument) {
-	return s.identifier, s.documents
+func (s *OpMsgSection) Section() (string, []wirebson.RawDocument) {
+	return s.Identifier, s.Documents
 }

--- a/op_msg_section.go
+++ b/op_msg_section.go
@@ -22,11 +22,16 @@ import (
 // OpMsgSection is one or more sections contained in an OpMsg.
 type OpMsgSection struct {
 	// The order of fields is weird to make the struct smaller due to alignment.
-	// The wire order is: Kind, Identifier, Documents.
+	// The wire order is: Kind, Identifier, documents.
 
 	Identifier string
-	Documents  []wirebson.RawDocument
+	documents  []wirebson.RawDocument
 	Kind       byte
+}
+
+// Documents returns all documents of that section.
+func (msg *OpMsgSection) Documents() []wirebson.RawDocument {
+	return msg.documents
 }
 
 // checkSections checks given sections.
@@ -49,8 +54,8 @@ func checkSections(sections []OpMsgSection) error {
 				return lazyerrors.New("kind 0 section has identifier")
 			}
 
-			if len(s.Documents) != 1 {
-				return lazyerrors.Errorf("kind 0 section has %d documents", len(s.Documents))
+			if len(s.documents) != 1 {
+				return lazyerrors.Errorf("kind 0 section has %d documents", len(s.documents))
 			}
 
 		case 1:

--- a/op_msg_test.go
+++ b/op_msg_test.go
@@ -37,7 +37,7 @@ var msgTestCases = []testCase{
 		},
 		msgBody: &OpMsg{
 			sections: []OpMsgSection{{
-				Documents: []wirebson.RawDocument{makeRawDocument(
+				documents: []wirebson.RawDocument{makeRawDocument(
 					"buildInfo", int32(1),
 					"lsid", wirebson.MustDocument(
 						"id", wirebson.Binary{
@@ -81,7 +81,7 @@ var msgTestCases = []testCase{
 		},
 		msgBody: &OpMsg{
 			sections: []OpMsgSection{{
-				Documents: []wirebson.RawDocument{makeRawDocument(
+				documents: []wirebson.RawDocument{makeRawDocument(
 					"version", "5.0.0",
 					"gitVersion", "1184f004a99660de6f5e745573419bda8a28c0e9",
 					"modules", wirebson.MustArray(),
@@ -178,7 +178,7 @@ var msgTestCases = []testCase{
 		msgBody: &OpMsg{
 			sections: []OpMsgSection{
 				{
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "actor",
 						"ordered", true,
 						"writeConcern", wirebson.MustDocument(
@@ -190,7 +190,7 @@ var msgTestCases = []testCase{
 				{
 					Kind:       1,
 					Identifier: "documents",
-					Documents: []wirebson.RawDocument{
+					documents: []wirebson.RawDocument{
 						makeRawDocument(
 							"_id", wirebson.ObjectID{0x61, 0x2e, 0xc2, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01},
 							"actor_id", int32(1),
@@ -288,7 +288,7 @@ var msgTestCases = []testCase{
 		},
 		msgBody: &OpMsg{
 			sections: []OpMsgSection{{
-				Documents: []wirebson.RawDocument{makeRawDocument(
+				documents: []wirebson.RawDocument{makeRawDocument(
 					"insert", "values",
 					"documents", wirebson.MustArray(
 						wirebson.MustDocument(
@@ -354,7 +354,7 @@ var msgTestCases = []testCase{
 		msgBody: &OpMsg{
 			sections: []OpMsgSection{
 				{
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "TestInsertSimple",
 						"ordered", true,
 						"$db", "testinsertsimple",
@@ -363,7 +363,7 @@ var msgTestCases = []testCase{
 				{
 					Kind:       1,
 					Identifier: "documents",
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"_id", wirebson.ObjectID{0x63, 0x7c, 0xfa, 0xd8, 0x8d, 0xc3, 0xce, 0xcd, 0xe3, 0x8e, 0x1e, 0x6b},
 						"v", math.Copysign(0, -1),
 					)},
@@ -432,13 +432,13 @@ var msgTestCases = []testCase{
 				{
 					Kind:       1,
 					Identifier: "documents",
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"_id", wirebson.ObjectID{0x63, 0x8c, 0xec, 0x46, 0xaa, 0x77, 0x8b, 0xf3, 0x70, 0x10, 0x54, 0x29},
 						"a", float64(3),
 					)},
 				},
 				{
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "foo",
 						"ordered", true,
 						"$db", "test",
@@ -521,7 +521,7 @@ var msgTestCases = []testCase{
 				{
 					Kind:       1,
 					Identifier: "updates",
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"q", wirebson.MustDocument(
 							"a", float64(20),
 						),
@@ -535,7 +535,7 @@ var msgTestCases = []testCase{
 					)},
 				},
 				{
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"update", "foo",
 						"ordered", true,
 						"$db", "test",
@@ -605,13 +605,13 @@ var msgTestCases = []testCase{
 				{
 					Kind:       1,
 					Identifier: "documents",
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"_id", wirebson.ObjectID{0x63, 0x8c, 0xec, 0x46, 0xaa, 0x77, 0x8b, 0xf3, 0x70, 0x10, 0x54, 0x29},
 						"a", float64(3),
 					)},
 				},
 				{
-					Documents: []wirebson.RawDocument{makeRawDocument(
+					documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "fooo",
 						"ordered", true,
 						"$db", "test",

--- a/op_msg_test.go
+++ b/op_msg_test.go
@@ -36,8 +36,8 @@ var msgTestCases = []testCase{
 			OpCode:        OpCodeMsg,
 		},
 		msgBody: &OpMsg{
-			sections: []opMsgSection{{
-				documents: []wirebson.RawDocument{makeRawDocument(
+			sections: []OpMsgSection{{
+				Documents: []wirebson.RawDocument{makeRawDocument(
 					"buildInfo", int32(1),
 					"lsid", wirebson.MustDocument(
 						"id", wirebson.Binary{
@@ -80,8 +80,8 @@ var msgTestCases = []testCase{
 			OpCode:        OpCodeMsg,
 		},
 		msgBody: &OpMsg{
-			sections: []opMsgSection{{
-				documents: []wirebson.RawDocument{makeRawDocument(
+			sections: []OpMsgSection{{
+				Documents: []wirebson.RawDocument{makeRawDocument(
 					"version", "5.0.0",
 					"gitVersion", "1184f004a99660de6f5e745573419bda8a28c0e9",
 					"modules", wirebson.MustArray(),
@@ -176,9 +176,9 @@ var msgTestCases = []testCase{
 			OpCode:        OpCodeMsg,
 		},
 		msgBody: &OpMsg{
-			sections: []opMsgSection{
+			sections: []OpMsgSection{
 				{
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "actor",
 						"ordered", true,
 						"writeConcern", wirebson.MustDocument(
@@ -188,9 +188,9 @@ var msgTestCases = []testCase{
 					)},
 				},
 				{
-					kind:       1,
-					identifier: "documents",
-					documents: []wirebson.RawDocument{
+					Kind:       1,
+					Identifier: "documents",
+					Documents: []wirebson.RawDocument{
 						makeRawDocument(
 							"_id", wirebson.ObjectID{0x61, 0x2e, 0xc2, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01},
 							"actor_id", int32(1),
@@ -287,8 +287,8 @@ var msgTestCases = []testCase{
 			OpCode:        OpCodeMsg,
 		},
 		msgBody: &OpMsg{
-			sections: []opMsgSection{{
-				documents: []wirebson.RawDocument{makeRawDocument(
+			sections: []OpMsgSection{{
+				Documents: []wirebson.RawDocument{makeRawDocument(
 					"insert", "values",
 					"documents", wirebson.MustArray(
 						wirebson.MustDocument(
@@ -352,18 +352,18 @@ var msgTestCases = []testCase{
 			OpCode:        OpCodeMsg,
 		},
 		msgBody: &OpMsg{
-			sections: []opMsgSection{
+			sections: []OpMsgSection{
 				{
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "TestInsertSimple",
 						"ordered", true,
 						"$db", "testinsertsimple",
 					)},
 				},
 				{
-					kind:       1,
-					identifier: "documents",
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Kind:       1,
+					Identifier: "documents",
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"_id", wirebson.ObjectID{0x63, 0x7c, 0xfa, 0xd8, 0x8d, 0xc3, 0xce, 0xcd, 0xe3, 0x8e, 0x1e, 0x6b},
 						"v", math.Copysign(0, -1),
 					)},
@@ -428,17 +428,17 @@ var msgTestCases = []testCase{
 		},
 		msgBody: &OpMsg{
 			Flags: OpMsgFlags(OpMsgChecksumPresent),
-			sections: []opMsgSection{
+			sections: []OpMsgSection{
 				{
-					kind:       1,
-					identifier: "documents",
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Kind:       1,
+					Identifier: "documents",
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"_id", wirebson.ObjectID{0x63, 0x8c, 0xec, 0x46, 0xaa, 0x77, 0x8b, 0xf3, 0x70, 0x10, 0x54, 0x29},
 						"a", float64(3),
 					)},
 				},
 				{
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "foo",
 						"ordered", true,
 						"$db", "test",
@@ -517,11 +517,11 @@ var msgTestCases = []testCase{
 		},
 		msgBody: &OpMsg{
 			Flags: OpMsgFlags(OpMsgChecksumPresent),
-			sections: []opMsgSection{
+			sections: []OpMsgSection{
 				{
-					kind:       1,
-					identifier: "updates",
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Kind:       1,
+					Identifier: "updates",
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"q", wirebson.MustDocument(
 							"a", float64(20),
 						),
@@ -535,7 +535,7 @@ var msgTestCases = []testCase{
 					)},
 				},
 				{
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"update", "foo",
 						"ordered", true,
 						"$db", "test",
@@ -601,17 +601,17 @@ var msgTestCases = []testCase{
 		},
 		msgBody: &OpMsg{
 			Flags: OpMsgFlags(OpMsgChecksumPresent),
-			sections: []opMsgSection{
+			sections: []OpMsgSection{
 				{
-					kind:       1,
-					identifier: "documents",
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Kind:       1,
+					Identifier: "documents",
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"_id", wirebson.ObjectID{0x63, 0x8c, 0xec, 0x46, 0xaa, 0x77, 0x8b, 0xf3, 0x70, 0x10, 0x54, 0x29},
 						"a", float64(3),
 					)},
 				},
 				{
-					documents: []wirebson.RawDocument{makeRawDocument(
+					Documents: []wirebson.RawDocument{makeRawDocument(
 						"insert", "fooo",
 						"ordered", true,
 						"$db", "test",

--- a/wire_test.go
+++ b/wire_test.go
@@ -129,6 +129,7 @@ func testMessages(t *testing.T, testCases []testCase) {
 				if msg, ok := tc.msgBody.(*OpMsg); ok {
 					assert.NotPanics(t, func() {
 						_ = msg.RawSection0()
+						_ = msg.RawSections1()
 						_, _ = msg.RawSections()
 						_, _ = msg.RawDocument()
 					})
@@ -214,6 +215,7 @@ func fuzzMessages(f *testing.F, testCases []testCase) {
 				if msg, ok := msgBody.(*OpMsg); ok {
 					assert.NotPanics(t, func() {
 						_ = msg.RawSection0()
+						_ = msg.RawSections1()
 						_, _ = msg.RawSections()
 						_, _ = msg.RawDocument()
 					})

--- a/wire_test.go
+++ b/wire_test.go
@@ -131,6 +131,10 @@ func testMessages(t *testing.T, testCases []testCase) {
 						_ = msg.RawSection0()
 						_, _ = msg.RawSections()
 						_, _ = msg.RawDocument()
+
+						for _, section := range msg.Sections() {
+							_ = section.Documents()
+						}
 					})
 				}
 			})

--- a/wire_test.go
+++ b/wire_test.go
@@ -129,7 +129,6 @@ func testMessages(t *testing.T, testCases []testCase) {
 				if msg, ok := tc.msgBody.(*OpMsg); ok {
 					assert.NotPanics(t, func() {
 						_ = msg.RawSection0()
-						_ = msg.RawSections1()
 						_, _ = msg.RawSections()
 						_, _ = msg.RawDocument()
 					})
@@ -215,7 +214,6 @@ func fuzzMessages(f *testing.F, testCases []testCase) {
 				if msg, ok := msgBody.(*OpMsg); ok {
 					assert.NotPanics(t, func() {
 						_ = msg.RawSection0()
-						_ = msg.RawSections1()
 						_, _ = msg.RawSections()
 						_, _ = msg.RawDocument()
 					})


### PR DESCRIPTION
Closes FerretDB/engineering#179.

To convert `RawDocument` to `types.Document`, both sections need to be exposed.