### PR TITLE
Do not use iterator yet

### DIFF
--- a/check.go
+++ b/check.go
@@ -26,9 +26,8 @@ import (
 func checkNaN(v any) error {
 	switch v := v.(type) {
 	case *wirebson.Document:
-		for i := range v.FieldNames() {
+		for i := range v.Len() {
 			_, f := v.GetByIndex(i)
-
 			if err := checkNaN(f); err != nil {
 				return err
 			}

--- a/wirebson/document.go
+++ b/wirebson/document.go
@@ -119,10 +119,11 @@ func (doc *Document) FieldNames() []string {
 // If document contains duplicate field names, it returns the first one.
 // To get other fields, a for/range loop can be used with [Document.Len] and [Document.GetByIndex].
 // Or iterators.
+// TODO https://github.com/FerretDB/wire/issues/9
 func (doc *Document) Get(name string) any {
-	for f, v := range doc.All() {
-		if name == f {
-			return v
+	for _, f := range doc.fields {
+		if f.name == name {
+			return f.value
 		}
 	}
 


### PR DESCRIPTION
Closes #9.

We don't want to add `goexperiment` in FerretDB.