### PR TITLE
Add Codecov to CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,34 @@
+---
+# https://docs.codecov.com/docs/codecovyml-reference
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+# https://docs.codecov.com/docs/coverage-configuration
+coverage:
+  range: "50...65"
+
+  # https://docs.codecov.com/docs/commit-status
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 50%
+
+# https://docs.codecov.com/docs/flags#recommended-automatic-flag-management
+flag_management:
+  default_rules:
+    carryforward: false
+
+# https://docs.codecov.com/docs/pull-request-comments
+comment:
+  layout: reach,diff,files,flags
+
+# https://docs.codecov.com/docs/github-checks
+# Annotations may be hidden by pressing the "a" key or by unselecting "Show annotations" in the top right of the file.
+github_checks:
+  annotations: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -82,7 +82,7 @@ jobs:
       # If secrets are unavailable (for example, for a pull request from a fork), it fallbacks to the tokenless uploads.
       #
       # Unfortunately, it seems that tokenless uploads fail too often.
-      # See https://github.com/codecov/codecov-action/issues/837.
+      # See https://github.com/codecov/feedback/issues/301.
       #
       # We also can't use ${{ vars.CODECOV_TOKEN }}: https://github.com/orgs/community/discussions/44322
       - name: Upload coverage information to codecov

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,7 +89,7 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v4
         with:
-          token: 44625ce5-0586-4c09-93b3-8135f5fc2fb5
+          token: 69371c38-548a-488e-8843-bfbbf32810bd
           files: ./cover.txt
           flags: test
           fail_ci_if_error: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           token: 44625ce5-0586-4c09-93b3-8135f5fc2fb5
           files: ./cover.txt
-          flags: unit
+          flags: test
           fail_ci_if_error: true
           verbose: true
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,6 +78,23 @@ jobs:
       - name: Run linters
         run: bin/task lint
 
+      # The token is not required but should make uploads more stable.
+      # If secrets are unavailable (for example, for a pull request from a fork), it fallbacks to the tokenless uploads.
+      #
+      # Unfortunately, it seems that tokenless uploads fail too often.
+      # See https://github.com/codecov/codecov-action/issues/837.
+      #
+      # We also can't use ${{ vars.CODECOV_TOKEN }}: https://github.com/orgs/community/discussions/44322
+      - name: Upload coverage information to codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          token: 44625ce5-0586-4c09-93b3-8135f5fc2fb5
+          files: ./cover.txt
+          flags: unit
+          fail_ci_if_error: true
+          verbose: true
+
       - name: Check dirty
         run: |
           git status

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,12 +75,12 @@ tasks:
   test-short:
     desc: "Run short tests"
     cmds:
-      - go test -short -race ./...
+      - go test -short -race -coverpkg=./... -coverprofile=cover.txt ./...
 
   test:
     desc: "Run all tests (requires MONGODB_URI set)"
     cmds:
-      - go test -race -count=1 ./...
+      - go test -race -count=1 -coverpkg=./... -coverprofile=cover.txt ./...
     env:
       MONGODB_URI: mongodb://localhost:27017/
 


### PR DESCRIPTION
Closes #5.
The proof of integration [here](https://app.codecov.io/gh/FerretDB/wire/pulls). As mentioned by the bot, the actual results will be shown after the merge.