### PR TITLE
Add `mongodb+srv://` support to wireclient

### DIFF
--- a/wireclient/wireclient.go
+++ b/wireclient/wireclient.go
@@ -77,6 +77,7 @@ func lookupSrvURI(ctx context.Context, u *url.URL) error {
 
 	srv := srvs[0]
 	u.Host = net.JoinHostPort(strings.TrimSuffix(srv.Target, "."), strconv.Itoa(int(srv.Port)))
+	u.Scheme = "mongodb"
 
 	return nil
 }

--- a/wireclient/wireclient.go
+++ b/wireclient/wireclient.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -63,6 +64,23 @@ func New(c net.Conn, l *slog.Logger) *Conn {
 	}
 }
 
+// lookupSrvURI converts mongodb+srv:// URI to mongodb:// URI, performing the simplest SRV lookup.
+func lookupSrvURI(ctx context.Context, u *url.URL) error {
+	_, srvs, err := net.DefaultResolver.LookupSRV(ctx, "mongodb", "tcp", u.Hostname())
+	if err != nil {
+		return fmt.Errorf("lookupSrvURI: SRV lookup failed: %w", err)
+	}
+
+	if len(srvs) != 1 {
+		return fmt.Errorf("lookupSrvURI: expected exactly one SRV record, got %d", len(srvs))
+	}
+
+	srv := srvs[0]
+	u.Host = net.JoinHostPort(strings.TrimSuffix(srv.Target, "."), strconv.Itoa(int(srv.Port)))
+
+	return nil
+}
+
 // Connect creates a new connection for the given MongoDB URI.
 // Credentials are ignored.
 //
@@ -74,6 +92,12 @@ func Connect(ctx context.Context, uri string, l *slog.Logger) (*Conn, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("wireclient.Connect: %w", err)
+	}
+
+	if u.Scheme == "mongodb+srv" {
+		if err = lookupSrvURI(ctx, u); err != nil {
+			return nil, fmt.Errorf("wireclient.Connect: %w", err)
+		}
 	}
 
 	if u.Scheme != "mongodb" {

--- a/wireclient/wireclient_test.go
+++ b/wireclient/wireclient_test.go
@@ -17,6 +17,7 @@ package wireclient
 import (
 	"context"
 	"log/slog"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -93,12 +94,27 @@ func databaseName(tb testing.TB) string {
 	return strings.ReplaceAll(tb.Name(), "/", "_")
 }
 
+func TestLookupSrvURI(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("mongodb+srv://username:password@cts-vcore.mongocluster.cosmos.azure.com/database")
+	require.NoError(t, err)
+
+	err = lookupSrvURI(t.Context(), u)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"mongodb+srv://username:password@fc-f6de9018d614-000.mongocluster.cosmos.azure.com:10260/database",
+		u.String(),
+	)
+}
+
 func TestConn(t *testing.T) {
 	t.Parallel()
 
 	uri := setup(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	t.Cleanup(cancel)
 
 	t.Run("Login", func(t *testing.T) {

--- a/wireclient/wireclient_test.go
+++ b/wireclient/wireclient_test.go
@@ -102,11 +102,7 @@ func TestLookupSrvURI(t *testing.T) {
 
 	err = lookupSrvURI(t.Context(), u)
 	require.NoError(t, err)
-	assert.Equal(
-		t,
-		"mongodb+srv://username:password@fc-f6de9018d614-000.mongocluster.cosmos.azure.com:10260/database",
-		u.String(),
-	)
+	assert.Equal(t, "mongodb://username:password@fc-f6de9018d614-000.mongocluster.cosmos.azure.com:10260/database", u.String())
 }
 
 func TestConn(t *testing.T) {


### PR DESCRIPTION
Closes #130.