### PR TITLE
Do not freeze returned documents

### DIFF
--- a/op_msg.go
+++ b/op_msg.go
@@ -238,7 +238,7 @@ func (msg *OpMsg) MarshalBinary() ([]byte, error) {
 	return b, nil
 }
 
-// Document returns the value of msg as decoded frozen [*wirebson.Document].
+// Document returns the value of msg as decoded [*wirebson.Document].
 // It may be shallowly or deeply decoded.
 //
 // The error is returned if msg contains anything other than a single section of kind 0
@@ -254,12 +254,10 @@ func (msg *OpMsg) Document() (*wirebson.Document, error) {
 		return nil, lazyerrors.Error(err)
 	}
 
-	doc.Freeze()
-
 	return doc, nil
 }
 
-// DocumentDeep returns the value of msg as deeply decoded frozen [*wirebson.Document].
+// DocumentDeep returns the value of msg as deeply decoded [*wirebson.Document].
 //
 // The error is returned if msg contains anything other than a single section of kind 0
 // with a single document.
@@ -273,8 +271,6 @@ func (msg *OpMsg) DocumentDeep() (*wirebson.Document, error) {
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
-
-	doc.Freeze()
 
 	return doc, nil
 }
@@ -297,7 +293,7 @@ func (msg *OpMsg) RawDocument() (wirebson.RawDocument, error) {
 	return msg.DocumentRaw()
 }
 
-// Section0 returns the frozen [*wirebson.Document] decoded from the section of kind 0.
+// Section0 returns the [*wirebson.Document] decoded from the section of kind 0.
 // It may be shallowly or deeply decoded.
 //
 // Most callers should use [OpMsg.Document] instead.
@@ -309,8 +305,6 @@ func (msg *OpMsg) Section0() (*wirebson.Document, error) {
 				return nil, lazyerrors.Error(err)
 			}
 
-			doc.Freeze()
-
 			return doc, nil
 		}
 	}
@@ -319,7 +313,7 @@ func (msg *OpMsg) Section0() (*wirebson.Document, error) {
 	panic("not reached")
 }
 
-// Sections returns the frozen [*wirebson.Document] decoded from the section of kind 0
+// Sections returns the [*wirebson.Document] decoded from the section of kind 0
 // (it may be shallowly or deeply decoded),
 // the raw value of that document,
 // and the concatenation of raw values of all sections with kind 1.
@@ -339,8 +333,6 @@ func (msg *OpMsg) Sections() (*wirebson.Document, wirebson.RawDocument, []byte, 
 			if doc, err = spec.Decode(); err != nil {
 				return nil, nil, nil, lazyerrors.Error(err)
 			}
-
-			doc.Freeze()
 
 		case 1:
 			for _, d := range s.documents {

--- a/op_query.go
+++ b/op_query.go
@@ -158,7 +158,7 @@ func (query *OpQuery) MarshalBinary() ([]byte, error) {
 	return b, nil
 }
 
-// Query returns decoded frozen query document.
+// Query returns decoded query document.
 // It may be shallowly or deeply decoded.
 func (query *OpQuery) Query() (*wirebson.Document, error) {
 	doc, err := query.query.Decode()
@@ -166,19 +166,15 @@ func (query *OpQuery) Query() (*wirebson.Document, error) {
 		return nil, lazyerrors.Error(err)
 	}
 
-	doc.Freeze()
-
 	return doc, nil
 }
 
-// QueryDeep returns deeply decoded frozen query document.
+// QueryDeep returns deeply decoded query document.
 func (query *OpQuery) QueryDeep() (*wirebson.Document, error) {
 	doc, err := query.query.DecodeDeep()
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
-
-	doc.Freeze()
 
 	return doc, nil
 }
@@ -188,7 +184,7 @@ func (query *OpQuery) QueryRaw() wirebson.RawDocument {
 	return query.query
 }
 
-// ReturnFieldsSelector returns decoded frozen returnFieldsSelector document, or nil.
+// ReturnFieldsSelector returns decoded returnFieldsSelector document, or nil.
 // It may be shallowly or deeply decoded.
 func (query *OpQuery) ReturnFieldsSelector() (*wirebson.Document, error) {
 	if query.returnFieldsSelector == nil {
@@ -200,12 +196,10 @@ func (query *OpQuery) ReturnFieldsSelector() (*wirebson.Document, error) {
 		return nil, lazyerrors.Error(err)
 	}
 
-	doc.Freeze()
-
 	return doc, nil
 }
 
-// ReturnFieldsSelectorDeep returns deeply decoded frozen returnFieldsSelector document, or nil.
+// ReturnFieldsSelectorDeep returns decoded returnFieldsSelector document, or nil.
 func (query *OpQuery) ReturnFieldsSelectorDeep() (*wirebson.Document, error) {
 	if query.returnFieldsSelector == nil {
 		return nil, nil
@@ -215,8 +209,6 @@ func (query *OpQuery) ReturnFieldsSelectorDeep() (*wirebson.Document, error) {
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
-
-	doc.Freeze()
 
 	return doc, nil
 }

--- a/op_reply.go
+++ b/op_reply.go
@@ -132,7 +132,7 @@ func (reply *OpReply) MarshalBinary() ([]byte, error) {
 	return b, nil
 }
 
-// Document returns decoded frozen document, or nil.
+// Document returns decoded document, or nil.
 // It may be shallowly or deeply decoded.
 func (reply *OpReply) Document() (*wirebson.Document, error) {
 	if reply.document == nil {
@@ -144,12 +144,10 @@ func (reply *OpReply) Document() (*wirebson.Document, error) {
 		return nil, lazyerrors.Error(err)
 	}
 
-	doc.Freeze()
-
 	return doc, nil
 }
 
-// DocumentDeep returns deeply decoded frozen document, or nil.
+// DocumentDeep returns deeply decoded document, or nil.
 func (reply *OpReply) DocumentDeep() (*wirebson.Document, error) {
 	if reply.document == nil {
 		return nil, nil
@@ -159,8 +157,6 @@ func (reply *OpReply) DocumentDeep() (*wirebson.Document, error) {
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
-
-	doc.Freeze()
 
 	return doc, nil
 }

--- a/wire_test.go
+++ b/wire_test.go
@@ -135,37 +135,12 @@ func testMessages(t *testing.T, testCases []testCase) {
 
 				switch msgBody := msgBody.(type) {
 				case *OpMsg:
-					doc, _ := msgBody.Document()
-					assert.Panics(t, func() { doc.Remove("foo") })
-
-					doc, _ = msgBody.DocumentDeep()
-					assert.Panics(t, func() { doc.Remove("foo") })
-
+					_, _ = msgBody.Document()
+					_, _ = msgBody.DocumentDeep()
 					_, _ = msgBody.DocumentRaw()
 
-					doc, _ = msgBody.Section0()
-					assert.Panics(t, func() { doc.Remove("foo") })
-
-					doc, _, _, _ = msgBody.Sections()
-					assert.Panics(t, func() { doc.Remove("foo") })
-				case *OpQuery:
-					doc, _ := msgBody.Query()
-					assert.Panics(t, func() { _ = doc.Add("foo", "bar") })
-
-					doc, _ = msgBody.QueryDeep()
-					assert.Panics(t, func() { _ = doc.Add("foo", "bar") })
-
-					doc, _ = msgBody.ReturnFieldsSelector()
-					assert.Panics(t, func() { _ = doc.Add("foo", "bar") })
-
-					doc, _ = msgBody.ReturnFieldsSelectorDeep()
-					assert.Panics(t, func() { _ = doc.Add("foo", "bar") })
-				case *OpReply:
-					doc, _ := msgBody.Document()
-					assert.Panics(t, func() { _ = doc.Replace("foo", "bar") })
-
-					doc, _ = msgBody.DocumentDeep()
-					assert.Panics(t, func() { _ = doc.Replace("foo", "bar") })
+					_, _ = msgBody.Section0()
+					_, _, _, _ = msgBody.Sections()
 				}
 			})
 


### PR DESCRIPTION
That breaks existing code (tests, tools, etc) that does not expect that.
Let's do the freezing and caching in the FerretDB code.

We still need the Copy methods after all, because they properly handle the Binary type.